### PR TITLE
Added Bundle-Name and Bundle-Vendor to avoid an empty column entry in…

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -1,7 +1,8 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: org.jcryptool.thirdparty
+Bundle-Name: Thirparty Repository
 Bundle-SymbolicName: org.jcryptool.thirdparty
 Bundle-Version: 0.0.1.qualifier
 Automatic-Module-Name: org.jcryptool.thirdparty
 Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-Vendor: jcryptool.org, by Simon Leischnig


### PR DESCRIPTION
… "About JCrypTool" -> "Installation Details" -> "Plugins"


Hi Simon, ich hab im Thridparty Repository einen Namen "Thirparty Repository" und einen Herausgeber "jcryptool.org, by Simon Leischnig" angegeben. Dieser wird unter "About JCrypTool" -> "Installation Details" -> "Plugins" angezeigt. Im Moment wird dort ein leeres Feld angezeigt. BE möchte, dass dort etwas steht.