### PR TITLE
[Signal-Plugin Dependency] Add com.google.protobuf:protobuf-java

### DIFF
--- a/releng/org.jcryptool.thirdparty.libraries.p2/pom.xml
+++ b/releng/org.jcryptool.thirdparty.libraries.p2/pom.xml
@@ -40,6 +40,10 @@
                                     <id>com.google.code.gson:gson:2.8.6</id>
                                     <source>true</source>
                                 </artifact>
+                                <artifact>
+                                    <id>com.google.protobuf:protobuf-java:3.22.0</id>
+                                    <source>true</source>
+                                </artifact>
                                 <!-- </artifact> -->
                             <!-- END: GOOGLE LIBRARIES -->
 


### PR DESCRIPTION
As preparation to add the signal-plugin

is this pom change enough?